### PR TITLE
Fixed TransitionView layout issue

### DIFF
--- a/ADTransitionController.podspec
+++ b/ADTransitionController.podspec
@@ -1,0 +1,26 @@
+{
+  "name": "ADTransitionController",
+  "version": "1.1.1",
+  "summary": "Drop-in replacement for UINavigationController with custom transition animations.",
+  "description": "                   ADTransitionController is a drop-in replacement for UINavigationController\n                   with custom transition animations.\n                   Concept was described on Applidium's\n\t\t\t\t   [website][http://applidium.com/en/news/uinavigationcontroller_with_custom_transitions/].\n",
+  "homepage": "http://applidium.github.io/ADTransitionController/",
+  "screenshots": "http://applidium.com/en/news/uinavigationcontroller_with_custom_transitions/adtransitioncontroller.jpg?13739936",
+  "license": {
+    "type": "NetBSD",
+    "file": "LICENSE"
+  },
+  "authors": {
+    "Applidium": "contact@applidium.com"
+  },
+  "source": {
+    "git": "https://github.com/applidium/ADTransitionController.git",
+    "tag": "v1.1.1"
+  },
+  "platforms": {
+    "ios": "6.0"
+  },
+  "source_files": "ADTransitionController/**/*.{h,m}",
+  "exclude_files": "TransitionDemo/**/*.{h,m}",
+  "frameworks": "QuartzCore",
+  "requires_arc": false
+}

--- a/ADTransitionController.podspec
+++ b/ADTransitionController.podspec
@@ -1,26 +1,20 @@
-{
-  "name": "ADTransitionController",
-  "version": "1.1.1",
-  "summary": "Drop-in replacement for UINavigationController with custom transition animations.",
-  "description": "                   ADTransitionController is a drop-in replacement for UINavigationController\n                   with custom transition animations.\n                   Concept was described on Applidium's\n\t\t\t\t   [website][http://applidium.com/en/news/uinavigationcontroller_with_custom_transitions/].\n",
-  "homepage": "http://applidium.github.io/ADTransitionController/",
-  "screenshots": "http://applidium.com/en/news/uinavigationcontroller_with_custom_transitions/adtransitioncontroller.jpg?13739936",
-  "license": {
-    "type": "NetBSD",
-    "file": "LICENSE"
-  },
-  "authors": {
-    "Applidium": "contact@applidium.com"
-  },
-  "source": {
-    "git": "https://github.com/applidium/ADTransitionController.git",
-    "tag": "v1.1.1"
-  },
-  "platforms": {
-    "ios": "6.0"
-  },
-  "source_files": "ADTransitionController/**/*.{h,m}",
-  "exclude_files": "TransitionDemo/**/*.{h,m}",
-  "frameworks": "QuartzCore",
-  "requires_arc": false
-}
+Pod::Spec.new do |s|
+  s.name         = "ADTransitionController"
+  s.version      = "1.1.1"
+  s.summary      = "Drop-in replacement for UINavigationController with custom transition animations."
+
+  s.description  = <<-DESC
+                   ADTransitionController is a drop-in replacement for UINavigationController with custom transition animations. Concept was described on Applidium's [website][http://applidium.com/en/news/uinavigationcontroller_with_custom_transitions/].
+                   DESC
+
+  s.homepage     = "http://applidium.github.io/ADTransitionController/"
+  s.screenshots  = "http://applidium.com/en/news/uinavigationcontroller_with_custom_transitions/adtransitioncontroller.jpg?13739936"
+  s.license      = { :type => "NetBSD", :file => "LICENSE" }
+  s.authors      = { "Applidium" => "contact@applidium.com" }
+  s.platform     = :ios, "6.0"
+  s.source       = { :git => "https://github.com/applidium/ADTransitionController.git", :tag => "v1.1.0" }
+  s.source_files  = "ADTransitionController/**/*.{h,m}"
+  s.exclude_files = "TransitionDemo/**/*.{h,m}"
+  s.framework  = "QuartzCore"
+  s.requires_arc = false
+end

--- a/ADTransitionController/ADTransitionController.m
+++ b/ADTransitionController/ADTransitionController.m
@@ -99,7 +99,7 @@ NSString * ADTransitionControllerAssociationKey = @"ADTransitionControllerAssoci
     [self.view addSubview:_toolbar];
     
     // Create and add the container view that will hold the controller views
-    _containerView = [[ADTransitionView alloc] initWithFrame:CGRectMake(self.view.frame.origin.x, self.view.frame.origin.y + navigationBarHeight, self.view.frame.size.width, self.view.frame.size.height - navigationBarHeight - toolbarHeight)];
+    _containerView = [[ADTransitionView alloc] initWithFrame:CGRectMake(self.view.bounds.origin.x, self.view.bounds.origin.y + navigationBarHeight, self.view.bounds.size.width, self.view.bounds.size.height - navigationBarHeight - toolbarHeight)];
     _containerView.autoresizesSubviews = YES;
     _containerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:_containerView];

--- a/ADTransitionController/ADTransitionController.m
+++ b/ADTransitionController/ADTransitionController.m
@@ -300,7 +300,7 @@ NSString * ADTransitionControllerAssociationKey = @"ADTransitionControllerAssoci
 
 - (NSArray *)popToViewController:(UIViewController *)viewController withTransition:(ADTransition *)transition {
     NSUInteger indexInViewController = [_viewControllers indexOfObject:viewController];
-    if (indexInViewController == NSNotFound || _isContainerViewTransitioning || _isNavigationBarTransitioning) {
+    if (indexInViewController == NSNotFound || _isContainerViewTransitioning || _isNavigationBarTransitioning || indexInViewController == [_viewControllers count] - 1) {
         return nil;
     }
     


### PR DESCRIPTION
The ADTransitionView within ADTransitionController was laying out using
the view’s frame, not its bounds; on iOS 6 this was causing the
transition view to be positioned 20 points below the top of the view if
the navigation bar is hidden.
