### PR TITLE
Added animationDidStop declaration to the ADTransition header to make ARC happy

### DIFF
--- a/ADTransitionController/ADTransition.h
+++ b/ADTransitionController/ADTransition.h
@@ -48,4 +48,5 @@ typedef enum {
 + (ADTransition *)nullTransition;
 - (ADTransition *)reverseTransition;
 - (NSArray *)getCircleApproximationTimingFunctions;
+- (void)animationDidStop:(CAAnimation *)animation finished:(BOOL)flag;
 @end


### PR DESCRIPTION
Fix for `.../Pods/ADTransitionController/ADTransitionController/ADDualTransition.m:62:16: No visible @interface for 'ADTransition' declares the selector 'animationDidStop:finished:'