### PR TITLE
Fix CATransaction completion block getting called too early in some situations

### DIFF
--- a/ADTransitionController/ADTransitioningDelegate.m
+++ b/ADTransitionController/ADTransitioningDelegate.m
@@ -110,6 +110,8 @@
     viewOut.layer.doubleSided = NO;
 
     [self _setupLayers:@[viewIn.layer, viewOut.layer]];
+  
+    [CATransaction begin];
     [CATransaction setCompletionBlock:^{
         [self _teardownLayers:@[viewIn.layer, viewOut.layer]];
         viewIn.layer.transform = CATransform3DIdentity;
@@ -142,6 +144,8 @@
     } else if (transition != nil) {
         NSAssert(FALSE, @"Unhandled ADTransition subclass!");
     }
+
+    [CATransaction commit];
 }
 
 - (void)_setupLayers:(NSArray *)layers {


### PR DESCRIPTION
In some situations when transitioning, I could see the completion block getting called before the animation was finished which would cause the view to basically be removed from the view stack.